### PR TITLE
Add changes from production

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,9 @@
 FROM ruby:2.5
 
-LABEL maintainer="Yinlin Chen <ylchen@vt.edu>"
-
 WORKDIR /usr/local/iiif
-
 RUN apt-get update && apt-get install -y imagemagick awscli
-
 RUN gem install --no-user-install --no-document iiif_s3
+COPY policy.xml /etc/ImageMagick-6/policy.xml
 
 COPY . .
-
-ENTRYPOINT ["./createiiif.sh"]
+CMD ["/usr/local/iiif/createiiif.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.5
-
+LABEL maintainer="Yinlin Chen <ylchen@vt.edu>"
 WORKDIR /usr/local/iiif
 RUN apt-get update && apt-get install -y imagemagick awscli
 RUN gem install --no-user-install --no-document iiif_s3

--- a/docker/create_iiif_s3.rb
+++ b/docker/create_iiif_s3.rb
@@ -1,6 +1,6 @@
 require 'iiif_s3'
 require 'open-uri'
-require_relative 'lib/iiif_s3/manifest_override'
+require_relative '../../lib/iiif_s3/manifest_override'
 IiifS3::Manifest.prepend IiifS3::ManifestOverride
 
 # Create directories on local disk for manifests/tiles to upload them to S3

--- a/docker/createiiif.sh
+++ b/docker/createiiif.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
+# Generate random directory and enter it
+TMPDIR=$(mktemp -d --tmpdir=$(pwd)/tmp)
+cd ${TMPDIR}
+cp ../../*.* .
 # Create directory structure (IIIF script requires it)
 mkdir -p ${ACCESS_DIR}
 # Fetch the images
-aws s3 sync s3://${SRC_BUCKET}/${ACCESS_DIR} ${ACCESS_DIR}
+aws s3 sync s3://${SRC_BUCKET}/${DIR_PREFIX}/${ACCESS_DIR} ${ACCESS_DIR}
 # Fetch the CSV file
-aws s3 sync s3://${SRC_BUCKET}/${CSV_PATH} .
+aws s3 cp s3://${SRC_BUCKET}/${CSV_PATH}/${CSV_NAME} .
 # Generate the tiles
-ruby create_iiif_s3.rb ${CSV_NAME} ${ACCESS_DIR} ${DEST_URL} ${DEST_BUCKET} --upload_to_s3=${UPLOAD_BOOL}
+ruby create_iiif_s3.rb ${CSV_NAME} ${ACCESS_DIR}/ ${DEST_URL} ${DEST_PREFIX} --upload_to_s3=${UPLOAD_BOOL}
+# Put CSV files in the proper place
+cp ${CSV_NAME} tmp/${DEST_PREFIX}/${COLLECTION_NAME}/${CSV_NAME::-4}/
 # Upload generated tiles
-aws s3 sync tmp/${DEST_BUCKET}/ s3://${AWS_BUCKET_NAME}/${DEST_BUCKET}
+aws s3 sync tmp/${DEST_PREFIX}/ s3://${DEST_BUCKET}/${DEST_PREFIX}/
+# Delete tmpdir
+rm -rf ${TMPDIR}

--- a/docker/env.list
+++ b/docker/env.list
@@ -1,0 +1,12 @@
+# For manual testing
+DIR_PREFIX=SpecScans/Women_of_Design
+ACCESS_DIR=Ms1988_017_Pfeiffer/Ms1988_017_Folder2/Ms1988_017_F002_001_Miller_Dr/Access
+SRC_BUCKET=vtlib-store
+DEST_BUCKET=img.cloud.lib.vt.edu
+# AWS_BUCKET_NAME is same as DEST_BUCKET (it's reqd by the script)
+AWS_BUCKET_NAME=vtlib-tmpstore
+CSV_PATH=SpecScans/Women_of_Design/Ms1988_017_Pfeiffer/CSV_to_upload/CSV_spreadsheets
+CSV_NAME=Ms1988_017_Folder2.csv
+DEST_URL=https://img.cloud.lib.vt.edu
+DEST_PREFIX=iawa
+UPLOAD_BOOL=false

--- a/docker/policy.xml
+++ b/docker/policy.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+<!ELEMENT policymap (policy)+>
+<!ELEMENT policy (#PCDATA)>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+  
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Let's prevent possible exploits by removing the right to use indirect reads.
+
+    <policy domain="path" rights="none" pattern="@*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, width, height, and disk resources
+  with SI prefixes (.e.g 100MB).  In addition, resource policies are maximums
+  for each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+<policymap>
+  <!-- <policy domain="resource" name="temporary-path" value="/tmp"/> -->
+  <policy domain="resource" name="memory" value="3GiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="width" value="50KP"/>
+  <policy domain="resource" name="height" value="50KP"/>
+  <policy domain="resource" name="area" value="1000MB"/>
+  <policy domain="resource" name="disk" value="100GiB"/>
+  <!-- <policy domain="resource" name="file" value="768"/> -->
+  <!-- <policy domain="resource" name="thread" value="4"/> -->
+  <!-- <policy domain="resource" name="throttle" value="0"/> -->
+  <!-- <policy domain="resource" name="time" value="3600"/> -->
+  <!-- <policy domain="system" name="precision" value="6"/> -->
+  <!-- not needed due to the need to use explicitly by mvg: -->
+  <!-- <policy domain="delegate" rights="none" pattern="MVG" /> -->
+  <!-- use curl -->
+  <policy domain="delegate" rights="none" pattern="URL" />
+  <policy domain="delegate" rights="none" pattern="HTTPS" />
+  <policy domain="delegate" rights="none" pattern="HTTP" />
+  <!-- in order to avoid to get image with password text -->
+  <policy domain="path" rights="none" pattern="@*"/>
+  <policy domain="cache" name="shared-secret" value="passphrase" stealth="true"/>
+</policymap>

--- a/examples/lambda-example.py
+++ b/examples/lambda-example.py
@@ -138,6 +138,10 @@ def createEnvList(content):
             value = env['value']
             region = {'name': 'AWS_REGION', 'value': value}
             envlist.append(region)
+        elif env['name'] == 'COLLECTION_NAME':
+            value = env['value']
+            collection_name = {'name': 'COLLECTION_NAME', 'value': value}
+            envlist.append(collection_name)
         elif env['name'] == 'UPLOAD_BOOL':
             value = env['value']
             upload = {'name': 'UPLOAD_BOOL', 'value': value}
@@ -166,9 +170,17 @@ def createEnvList(content):
             value = env['value']
             dest_bucket = {'name': 'DEST_BUCKET', 'value': value}
             envlist.append(dest_bucket)
+        elif env['name'] == 'DEST_PREFIX':
+            value = env['value']
+            dest_prefix = {'name': 'DEST_PREFIX', 'value': value}
+            envlist.append(dest_prefix)
         elif env['name'] == 'DEST_URL':
             value = env['value']
             dest_url = {'name': 'DEST_URL', 'value': value}
             envlist.append(dest_url)
+        elif env['name'] == 'DIR_PREFIX':
+            value = env['value']
+            dir_prefix = {'name': 'DIR_PREFIX', 'value': value}
+            envlist.append(dir_prefix)
 
     return envlist


### PR DESCRIPTION
This pull request merges all the changes I made to run the tile generation in production.

Notable changes include -
- Use of `mktemp` to create unique temporary directories for each job, since the same instance could be running multiple jobs at the same location while using Docker bind-mount volumes.
- Add a `COLLECTION_NAME` constant, since the Batch job needs to create/upload to the proper folder.
- An `env.list` file to specify all the variables if the image is being tested outside of the AWS pipeline.

@yinlinchen I just copied and pasted all the changes I made; so I might have overwritten something important that needs to be there. Let me know, and I can make changes to this pull request.